### PR TITLE
Make sure we show detailed info on failure

### DIFF
--- a/src/clj/yummy/config.clj
+++ b/src/clj/yummy/config.clj
@@ -3,6 +3,7 @@
   (:require [clojure.spec.alpha :as spec]
             [clojure.string     :as string]
             [yummy.parser       :as parser]
+            [clojure.pprint     :as pprint]
             [expound.alpha      :as expound]))
 
 (def ^:dynamic *die-fn* nil)
@@ -12,8 +13,12 @@
 (defn die!
   "Exit early"
   [^Exception e msg]
-  (let [estr (cond-> msg (some? e) (str ": " (.getMessage e)))]
-    (binding [*out* *err*] (println estr))
+  (let [estr (cond-> msg
+               (some? e)
+               (str ": " (ex-message e)))]
+    (binding [*out* *err*]
+      (println estr)
+      (some-> e Throwable->map pprint/pprint))
     (System/exit 1)))
 
 (defn configuration-property


### PR DESCRIPTION
dumps everything we know about the exception via (root ex, cause, message, data (if ex-info), stacktrace) via Throwable->map + pprint. 

For `(throw (ex-info "asdf" {:a 1} (Exception. "xxx")))` we'd get something like the following (taking the example message from our case):

```clj
failed to do something important <this is the msg arg basically>: asdf
{:via
 [{:type clojure.lang.ExceptionInfo,
   :message "asdf",
   :data {:a 1},
   :at
   [obwald.main$eval13198
    invokeStatic
    "form-init5204581841907778384.clj"
    745]}
  {:type java.lang.Exception,
   :message "xxx",
   :at
   [obwald.main$eval13198
    invokeStatic
    "form-init5204581841907778384.clj"
    745]}],
 :trace
 [[obwald.main$eval13198
   invokeStatic
   "form-init5204581841907778384.clj"
   745]
  [obwald.main$eval13198 invoke "form-init5204581841907778384.clj" 745]
  [clojure.lang.Compiler eval "Compiler.java" 7177]
  [clojure.lang.Compiler eval "Compiler.java" 7132]
  [clojure.core$eval invokeStatic "core.clj" 3214]
  [clojure.core$eval invoke "core.clj" 3210]
  [clojure.main$repl$read_eval_print__9086$fn__9089
   invoke
   "main.clj"
   437]
  [clojure.main$repl$read_eval_print__9086 invoke "main.clj" 437]
  [clojure.main$repl$fn__9095 invoke "main.clj" 458]
  [clojure.main$repl invokeStatic "main.clj" 458]
  [clojure.main$repl doInvoke "main.clj" 368]
  [clojure.lang.RestFn invoke "RestFn.java" 1523]
  [nrepl.middleware.interruptible_eval$evaluate
   invokeStatic
   "interruptible_eval.clj"
   79]
  [nrepl.middleware.interruptible_eval$evaluate
   invoke
   "interruptible_eval.clj"
   55]
  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__6239$fn__6243
   invoke
   "interruptible_eval.clj"
   142]
  [clojure.lang.AFn run "AFn.java" 22]
  [nrepl.middleware.session$session_exec$main_loop__6340$fn__6344
   invoke
   "session.clj"
   171]
  [nrepl.middleware.session$session_exec$main_loop__6340
   invoke
   "session.clj"
   170]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 834]],
 :cause "xxx"}
```

